### PR TITLE
[setup.py] added missing dependency Pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='python-geotiepoints',
                    "Topic :: Scientific/Engineering"],
       url="https://github.com/adybbroe/python-geotiepoints",
       packages = ['geotiepoints'],      
-      install_requires=['numpy', 'scipy', 'pyresample'],
+      install_requires=['numpy', 'scipy', 'pyresample', 'pandas'],
       zip_safe = False
       )
 


### PR DESCRIPTION
`basic_interpolator` uses pandas, but pandas was not in the `install_requires` section of setup.py

This commit adds `pandas` to the `install_requires` in setup.py